### PR TITLE
Update Twitter/GitHub/LinkedIn links on staff-page

### DIFF
--- a/staff-page.php
+++ b/staff-page.php
@@ -21,20 +21,19 @@
         <?php if($meta['staff-twitter'] && $meta['staff-twitter'][0]) { ?>
           <a href="http://twitter.com/<?php print $meta['staff-twitter'][0] ?>">
           <span class="sficon-twitter"></span>
-	        <span><?php print $meta['staff-twitter'][0] ?>&nbsp;&nbsp;</span></a>
+	        <span>Twitter&nbsp;&nbsp;</span></a>
         <?php } ?>
-
-        <?php if($meta['staff-linkedin'] && $meta['staff-linkedin'][0]) { ?>
-          <a href="http://www.linkedin.com/in/<?php print $meta['staff-linkedin'][0] ?>">
-	          <span class="sficon-linkedin"></span>
-	          <span><?php print $meta['staff-linkedin'][0] ?>&nbsp;&nbsp;</span></a>
-        <?php } ?>
-
-
+				
         <?php if($meta['staff-github'] && $meta['staff-github'][0]) { ?>
           <a href="http://www.github.com/<?php print $meta['staff-github'][0] ?>">
 	          <span class="sficon-github"></span>
-	          <span><?php print $meta['staff-github'][0] ?>&nbsp;&nbsp;</span></a>
+	          <span>GitHub&nbsp;&nbsp;</span></a>
+        <?php } ?>		
+				
+        <?php if($meta['staff-linkedin'] && $meta['staff-linkedin'][0]) { ?>
+          <a href="http://www.linkedin.com/in/<?php print $meta['staff-linkedin'][0] ?>">
+	          <span class="sficon-linkedin"></span>
+	          <span>LinkedIn&nbsp;&nbsp;</span></a>
         <?php } ?>
     	</div>
     </div>


### PR DESCRIPTION
Update to match style on current site.
1. Change order from Twitter–LinkedIn–GitHub to Twitter–GitHub–LinkedIn
2. Change link text from handles to "Twitter", "GitHub", and "LinkedIn"

What the new site is showing right now:
<img width="582" alt="screen shot 2016-10-27 at 10 31 02 pm" src="https://cloud.githubusercontent.com/assets/3474451/19792086/2dc5a6d8-9c95-11e6-8fb5-ca58b4eb2e6b.png">

What the current live site shows (and what is proposed with this pull request):
<img width="420" alt="screen shot 2016-10-27 at 10 31 12 pm" src="https://cloud.githubusercontent.com/assets/3474451/19792095/370cc69a-9c95-11e6-8bfc-08ff1a091407.png">

I don't actually mind having the handles for Twitter and GitHub, _but_, the LinkedIn handle names are quite long and ugly, and we should be consistent with either just handles or just "Twitter"/"GitHub"/"LinkedIn" — hence why it makes sense that the current live site is the way it is.
